### PR TITLE
concurrency fixes

### DIFF
--- a/DICE/ListViewController.h
+++ b/DICE/ListViewController.h
@@ -14,7 +14,7 @@
 
 @interface ListViewController : UIViewController <ReportCollectionView, UITableViewDataSource, UITableViewDelegate> {}
 
-@property (strong, nonatomic) NSMutableArray *reports;
+@property (strong, nonatomic) NSArray *reports;
 @property (strong, nonatomic) id<ReportCollectionViewDelegate> delegate;
 @property (strong, nonatomic) UITableViewCell *selectedCell;
 @property (strong, nonatomic) UIActivityIndicatorView *spinner;

--- a/DICE/ListViewController.m
+++ b/DICE/ListViewController.m
@@ -24,7 +24,7 @@
     [super viewDidLoad];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshReportList:) name:[ReportNotification reportImportFinished] object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateReportImportProgress:) name:[ReportNotification reportImportProgress] object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshReportList:) name:[ReportNotification reportImportProgress] object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshReportList:) name:[ReportNotification reportsLoaded] object:nil];
     
     self.title = @"Disconnected Interactive Content Explorer";
@@ -57,16 +57,9 @@
 - (void)refreshReportList:(NSNotification *)notification
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [_tableViewController.refreshControl endRefreshing];
-        [_tableView reloadData];
-    });
-}
-
-
-- (void)updateReportImportProgress:(NSNotification *)notification
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [_tableViewController.refreshControl endRefreshing];
+        if ([notification.name isEqualToString:[ReportNotification reportsLoaded]]) {
+            [_tableViewController.refreshControl endRefreshing];
+        }
         [_tableView reloadData];
     });
 }

--- a/DICE/ListViewController.m
+++ b/DICE/ListViewController.m
@@ -148,19 +148,7 @@
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
     // Return NO if you do not want the specified item to be editable.
-    return YES;
-}
-
-
-- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    if (editingStyle == UITableViewCellEditingStyleDelete) {
-        [self.reports removeObjectAtIndex:indexPath.row];
-        [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationFade];
-    }
-    else if (editingStyle == UITableViewCellEditingStyleInsert) {
-        // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view.
-    }
+    return NO;
 }
 
 

--- a/DICE/MapViewController.h
+++ b/DICE/MapViewController.h
@@ -16,7 +16,7 @@
 
 @interface MapViewController : UIViewController <ReportCollectionView, MKMapViewDelegate>
 
-@property (strong, nonatomic) NSMutableArray *reports;
+@property (strong, nonatomic) NSArray *reports;
 @property (strong, nonatomic) id<ReportCollectionViewDelegate> delegate;
 @property (strong, nonatomic) IBOutlet MKMapView *mapView;
 @property (strong, nonatomic) Report *selectedReport;

--- a/DICE/ReportAPI.h
+++ b/DICE/ReportAPI.h
@@ -7,21 +7,59 @@
 #import "Report.h"
 
 
+/**
+ This class provides static methods that return strings for notification names that
+ ReportAPI can produce.  ReportAPI will fire all noifications on the main thread.
+ */
 @interface ReportNotification : NSObject 
 
 /**
  This notification indicates a report was added to the list.
  This does not mean the report is imported and ready to view.
+ The NSNotification object userInfo dicationary contains
+ {
+     @"report": (Report*) the added report object,
+     @"index": (NSString*) integral index of the report in the reports array
+ }
  */
 + (NSString *)reportAdded;
+/**
+ This notification indicates that the app has started importing
+ a given report.
+ The NSNotification object userInfo dictionary contains
+ {
+     @"report": (Report*) the report being imported,
+     @"index": (NSString*) integral index of the report in the reports array
+ }
+ */
 + (NSString *)reportImportBegan;
+/**
+ This notification indicates progress on importing a given report.
+ The NSNotification object userInfo dictionary contains
+ {
+     @"report": (Report*) the report object being imported,
+     @"progress": (NSString*) integral number of files that have been imported,
+     @"totalNumberOfFiles": (NSString*) integral total number for files the report contains
+ }
+ */
 + (NSString *)reportImportProgress;
 /**
  This notification indicates that a report was fully
- imported and is ready to view.  This notification will 
- always dispatch on the main thread.
+ imported and is ready to view.
+ The NSNotificatoin object userInfo dictionary contains
+ {
+     @"report": (Report*) the report that was imported,
+     @"index": (NSString*) integral index of the report in the reports array
+ }
  */
 + (NSString *)reportImportFinished;
+/**
+ This notification indicates that ReportAPI has finished scanning for report files
+ in the Documents directory and has populated the report list with its findings.
+ The reports in the list may still be pending the import process, however, so 
+ may not yet be ready to view.
+ The NSNotification object has a nil userInfo dictionary.
+ */
 + (NSString *)reportsLoaded;
 
 @end

--- a/DICE/ReportAPI.h
+++ b/DICE/ReportAPI.h
@@ -32,7 +32,7 @@
 + (NSString *)userGuideReportID;
 
 - (void)importReportFromUrl:(NSURL *)reportURL afterImport:(void(^)(Report *))afterImportBlock;
-- (NSMutableArray*)getReports;
+- (NSArray*)getReports;
 - (void)loadReports;
 - (void)loadReportsWithCompletionHandler:(void(^) (void))completionHandler;
 - (Report *)reportForID:(NSString *)reportID;

--- a/DICE/ReportAPI.m
+++ b/DICE/ReportAPI.m
@@ -34,7 +34,8 @@
 @end
 
 
-@interface ReportAPI () {
+@interface ReportAPI ()
+{
     dispatch_queue_t backgroundQueue;
     NSMutableArray *reports;
     NSFileManager *fileManager;
@@ -44,6 +45,11 @@
 @end
 
 // TODO: implement report content hashing to detect new reports and duplicates
+// TODO: assess thread safety of reports array read/write and notifications - dispatch everything on main thread?
+/*
+     i think currently everything that reads the array is on the main thread, but we should address thread safety properly
+ */
+// TODO: use core data to build report store?
 
 @implementation ReportAPI
 
@@ -65,52 +71,61 @@
 {
     self = [super init];
     
-    if (self) {
-        reports = [[NSMutableArray alloc] init];
-        fileManager = [NSFileManager defaultManager];
-        backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-        documentsDir = [fileManager URLForDirectory:NSDocumentDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:nil];
+    if (!self) {
+        return nil;
     }
+    
+    reports = [[NSMutableArray alloc] init];
+    fileManager = [NSFileManager defaultManager];
+    backgroundQueue = dispatch_queue_create("dice_work", DISPATCH_QUEUE_CONCURRENT);
+    documentsDir = [fileManager URLForDirectory:NSDocumentDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:nil];
     
     return self;
 }
 
+- (void)dealloc
+{
+    dispatch_release(backgroundQueue);
+}
 
-- (NSMutableArray *)getReports
+- (NSArray *)getReports
 {
     return reports;
 }
-
 
 - (Report *)reportForID:(NSString *)reportID
 {
     return [reports filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"reportID == %@", reportID]].firstObject;
 }
 
-
 /*
- * Load the report zips and PDFs that are stored in the app's Documents directory
+ * Load the reports that are stored in the app's Documents directory
  */
 - (void)loadReports
 {
     NSLog(@"ReportAPI: loading reports from %@ ...", documentsDir);
-    [reports removeAllObjects];
-
-    NSDirectoryEnumerator *files = [fileManager enumeratorAtURL:documentsDir
-        includingPropertiesForKeys:@[NSURLNameKey, NSURLIsRegularFileKey, NSURLIsReadableKey, NSURLLocalizedNameKey]
-        options:(NSDirectoryEnumerationSkipsPackageDescendants | NSDirectoryEnumerationSkipsSubdirectoryDescendants)
-        errorHandler:nil];
     
-    for (NSURL *file in files) {
-        NSLog(@"ReportAPI: attempting to add report from file %@", file);
-        [self addReportFromFile:[NSURL URLWithString:file.lastPathComponent relativeToURL:documentsDir] afterComplete:nil];
-    }
+    dispatch_barrier_sync(backgroundQueue, ^{
+        [reports removeAllObjects];
+        
+        NSDirectoryEnumerator *files = [fileManager enumeratorAtURL:documentsDir
+            includingPropertiesForKeys:@[NSURLNameKey, NSURLIsRegularFileKey, NSURLIsReadableKey, NSURLLocalizedNameKey]
+            options:(NSDirectoryEnumerationSkipsPackageDescendants | NSDirectoryEnumerationSkipsSubdirectoryDescendants)
+            errorHandler:nil];
+        
+        for (NSURL *file in files) {
+            NSLog(@"ReportAPI: attempting to add report from file %@", file);
+            [self addReportFromFile:[NSURL URLWithString:file.lastPathComponent relativeToURL:documentsDir] afterComplete:nil];
+        }
+        
+        if ([reports count] == 0) {
+            [reports addObject:[self getUserGuideReport]];
+        }
+    });
     
-    if ([reports count] == 0) {
-        [reports addObject:[self getUserGuideReport]];
-    }
-    
-    [[NSNotificationCenter defaultCenter] postNotificationName:[ReportNotification reportsLoaded] object:self userInfo:nil];
+    dispatch_async(dispatch_get_main_queue(), ^{
+       [[NSNotificationCenter defaultCenter] postNotificationName:[ReportNotification reportsLoaded] object:self userInfo:nil];
+    });
 }
 
 
@@ -159,13 +174,14 @@
             // TODO: notify report removed
             [reports removeObject:placeHolder];
         }
-        
-        [[NSNotificationCenter defaultCenter]
-            postNotificationName:[ReportNotification reportAdded] object:self
-            userInfo:@{
-                @"report": report,
-                @"index": [NSString stringWithFormat:@"%lu", reports.count - 1]
-            }];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter]
+                postNotificationName:[ReportNotification reportAdded] object:self
+                userInfo:@{
+                    @"report": report,
+                    @"index": [NSString stringWithFormat:@"%lu", reports.count - 1]
+                }];
+        });
         
         NSString *fileExtension = file.pathExtension;
         
@@ -296,9 +312,11 @@
         if (![name hasSuffix:@"/"]) {
             NSString *filePath = [directory.path stringByAppendingPathComponent:name];
             NSString *basePath = [filePath stringByDeletingLastPathComponent];
-            if (![[NSFileManager defaultManager] createDirectoryAtPath:basePath withIntermediateDirectories:YES attributes:nil error:error]) {
-                [unzipFile close];
-                return NO;
+            if (![fileManager fileExistsAtPath:basePath]) {
+                if (![fileManager createDirectoryAtPath:basePath withIntermediateDirectories:YES attributes:nil error:error]) {
+                    [unzipFile close];
+                    return NO;
+                }
             }
             
             [[NSData data] writeToFile:filePath options:0 error:nil];
@@ -319,14 +337,16 @@
         
         if (filesExtracted % 25 == 0) {
             report.progress = filesExtracted;
-            [[NSNotificationCenter defaultCenter]
-                postNotificationName:[ReportNotification reportImportProgress]
-                object:self
-                userInfo:@{
-                    @"report": report,
-                    @"progress": [NSString stringWithFormat:@"%d", filesExtracted],
-                    @"totalNumberOfFiles": [NSString stringWithFormat:@"%d", totalNumberOfFiles]
-                }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[NSNotificationCenter defaultCenter]
+                    postNotificationName:[ReportNotification reportImportProgress]
+                    object:self
+                    userInfo:@{
+                        @"report": report,
+                        @"progress": [NSString stringWithFormat:@"%d", filesExtracted],
+                        @"totalNumberOfFiles": [NSString stringWithFormat:@"%d", totalNumberOfFiles]
+                    }];
+            });
         }
     }
     

--- a/DICE/ReportCollectionView.h
+++ b/DICE/ReportCollectionView.h
@@ -22,7 +22,7 @@
 @protocol ReportCollectionView
 
 // TODO: make this non-mutable and fix view classes that attempt to mutate it
-@property (strong, nonatomic) NSMutableArray *reports;
+@property (strong, nonatomic) NSArray *reports;
 @property (strong, nonatomic) id<ReportCollectionViewDelegate> delegate;
 
 @end

--- a/DICE/TileViewController.h
+++ b/DICE/TileViewController.h
@@ -10,7 +10,7 @@
 
 @interface TileViewController : UIViewController <ReportCollectionView, UICollectionViewDataSource, UICollectionViewDelegate>
 
-@property (strong, nonatomic) NSMutableArray *reports;
+@property (strong, nonatomic) NSArray *reports;
 @property (strong, nonatomic) id<ReportCollectionViewDelegate> delegate;
 @property (strong, nonatomic) UITableViewCell *selectedCell;
 @property (strong, nonatomic) UIActivityIndicatorView *spinner;


### PR DESCRIPTION
This merge includes some fixes for concurrency issues related to accessing the report list in ReportAPI and reloading the report list.  Now the app will handle adding and removing reports and pull-to-refresh while reports are simultaneously being unzipped.